### PR TITLE
switch to C-s as key into vterm-copy-mode

### DIFF
--- a/config/00-package-specific/vterm.el
+++ b/config/00-package-specific/vterm.el
@@ -50,7 +50,7 @@
   (define-key vterm-mode-map (kbd "<f12>") nil)
   (define-key vterm-mode-map (kbd "C-c n") 'multi-vterm-next)
   (define-key vterm-mode-map (kbd "C-c p") 'multi-vterm-prev)
-  (define-key vterm-mode-map (kbd "C-m") 'vterm-copy-mode)
+  (define-key vterm-mode-map (kbd "C-s") 'vterm-copy-mode)
   (define-key vterm-mode-map (kbd "C-c C-s") 'vterm-set-root-host-name))
 
 


### PR DESCRIPTION
1. C-m may take as RET key, and mislead the return key in some terminal